### PR TITLE
add link to Secure Headers gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ authenticated = ActiveSupport::SecurityUtils.secure_compare(
 
 
 ### Headers
-- [ ] Secure Headers (see gem)
+- [ ] Secure Headers (see [gem](https://github.com/twitter/secureheaders))
 - [ ] Content Security Policy
 
 


### PR DESCRIPTION
Perhaps `gem` is about https://github.com/twitter/secureheaders. If so, I would like to add a link.
